### PR TITLE
adds support for 'since' flag on Docker events client

### DIFF
--- a/ahab/__init__.py
+++ b/ahab/__init__.py
@@ -23,6 +23,10 @@ class Ahab(object):
 
     def listen(self):
         client = docker.APIClient(base_url=self.url, version=docker_client_version)
+
+        # the 'since' flag is to start reading from a particular event.
+        # see the docker SDK docs:
+        # https://docker-py.readthedocs.io/en/stable/client.html#docker.client.DockerClient.events
         for event in client.events(decode=True, since=self.since):
             for k in ['time', 'Time']:
                 if k in event:

--- a/ahab/__init__.py
+++ b/ahab/__init__.py
@@ -14,14 +14,16 @@ docker_client_version = '1.24'
 
 
 class Ahab(object):
-    def __init__(self, url='unix:///var/run/docker.sock', handlers=[]):
+    def __init__(self,
+                 url='unix:///var/run/docker.sock', handlers=[], since=None):
         self.url = url
         self.handlers = handlers if len(handlers) > 0 else [Ahab.default]
         self.data = defaultdict(dict)
+        self.since = since
 
     def listen(self):
         client = docker.APIClient(base_url=self.url, version=docker_client_version)
-        for event in client.events(decode=True):
+        for event in client.events(decode=True, since=self.since):
             for k in ['time', 'Time']:
                 if k in event:
                     event[k] = datetime.fromtimestamp(event[k])
@@ -38,6 +40,11 @@ class Ahab(object):
                 except docker.errors.NotFound:
                     data = self.data[i]
             self.handle(event, data)
+            # mark the last event seen so we can restart this listener
+            # without dropping events. the caller must be responsible for
+            # ensuring that handlers do not drop events, because they are
+            # fire-and-forget from this point.
+            self.since = get_time_nano(event)
 
     def handle(self, event, data):
         for handler in self.handlers:
@@ -72,6 +79,15 @@ def get_id(event):
     for k in ['id', 'ID', 'Id']:
         if k in event:
             return event[k]
+
+
+def get_time_nano(event):
+    time_nano = None
+    for k in ['timeNano', 'timenano']:
+        if k in event:
+            time_nano = event[k]
+            break
+    return time_nano
 
 
 __version__ = version()


### PR DESCRIPTION
Updates the listener to track state of the last event seen so that if callers need to restart the listener they can do so without dropping events. The caller must be responsible for ensuring that handlers do not drop events, because they are fire-and-forget once they enter the handler.

The Docker API does not provide unique event IDs but with the nanosecond precision timestamp we should have a enough timestamp that we can use it as the start of a page without dropping events.

cc @instacart/infra for review

---

Simple proof-of-concept

```python
import ahab

def handle(event, data):
    print(event)
    raise Exception('oh no')

since = None
for i in range(1,3):
    try:
        listener = ahab.Ahab(handlers=[handle], since=since)
        listener.listen()
    except:
        since = listener.since
        print('restarting listener')
```

Results:
```
{u'timeNano': 1542398060842299200, u'Actor': {u'Attributes': {u'type': u'bridge', u'container': u'f97812e5e0fcc69bef7207f048a75d6b34d9d6c9251dfee1de46d1ec2532a062', u'name': u'bridge'}, u'ID': u'6f1734b684c167d809d7e9ed3eb6c119de272d8aa9fb4cfdd5a70df776345b9f'}, u'time': datetime.datetime(2018, 11, 16, 14, 54, 20), u'Action': u'connect', u'scope': u'local', u'Type': u'network'}
restarting listener
{u'status': u'start', u'timeNano': 1542398061158697800, u'from': u'143926955519.dkr.ecr.us-east-1.amazonaws.com/vault:latest', u'Actor': {u'Attributes': {u'image': u'143926955519.dkr.ecr.us-east-1.amazonaws.com/vault:latest', u'name': u'vault-remote-isc-infra'}, u'ID': u'f97812e5e0fcc69bef7207f048a75d6b34d9d6c9251dfee1de46d1ec2532a062'}, u'time': datetime.datetime(2018, 11, 16, 14, 54, 21), u'Action': u'start', u'scope': u'local', u'Type': u'container', u'id': u'f97812e5e0fcc69bef7207f048a75d6b34d9d6c9251dfee1de46d1ec2532a062'}
restarting listener
```

Note that both events are received and that we don't double-send events.